### PR TITLE
Update build scripts

### DIFF
--- a/build-here/Makefile
+++ b/build-here/Makefile
@@ -15,7 +15,7 @@ ASP_OBJ_FILES := $(patsubst src/%.S,build/%.o,$(ASP_FILES))
 
 # settings for the compilers
 ifneq ($(C_FILES),)
-RISCV_PREFIX = riscv64-unknown-elf-
+RISCV_PREFIX = riscv32-unknown-elf-
 else
 RISCV_PREFIX = riscv64-unknown-elf-
 endif

--- a/build-here/link.ld
+++ b/build-here/link.ld
@@ -18,6 +18,7 @@ SECTIONS
 
     __global_pointer$ = .  + 0x800;
     .data : {
+        __bss_start = .;
         *(.sbss)
         *(COMMON)
         *(.bss)


### PR DESCRIPTION
Adds `__bss_start` to `link.ld` and uses `riscv32-unknown-elf-gcc` if C files are present.